### PR TITLE
Arruma cancelar que aparecia em português, como apontado pelo Rodrigo Santos

### DIFF
--- a/Comidinhas/Extensions/UIViewControllerAlertsExtension.swift
+++ b/Comidinhas/Extensions/UIViewControllerAlertsExtension.swift
@@ -18,7 +18,7 @@ extension UIViewController {
         self.present(alertController, animated: true, completion: completion)
     }
     
-    func displayConfirmationAlert(title: String, message: String, confirmTitle: String? = "Ok", cancelTitle: String? = "Cancelar", confirmHandler: ((UIAlertAction) -> Void)?) {
+    func displayConfirmationAlert(title: String, message: String, confirmTitle: String? = "Ok", cancelTitle: String? = "Cancel", confirmHandler: ((UIAlertAction) -> Void)?) {
         let alertController: UIAlertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let confirmAction: UIAlertAction = UIAlertAction(title: confirmTitle, style: .default, handler: confirmHandler)
         let cancelAction: UIAlertAction = UIAlertAction(title: cancelTitle, style: .cancel, handler: nil)


### PR DESCRIPTION
Arruma cancelar que aparecia em português, como apontado pelo professor Rodrigo Santos